### PR TITLE
Add Python ping GUI test app

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -1,0 +1,26 @@
+# Beschreibung
+
+Diese kleine Testanwendung demonstriert, wie man mit Python und `tkinter`
+eine moderne, minimalistische Oberfläche zum Pingen von Hosts erstellt. Die
+Applikation unterstützt IPv4- und IPv6-Adressen und zeigt die Ergebnisse in
+einem Protokollfenster an.
+
+## Features
+
+- Eingabefeld für Hostnamen oder IP-Adresse
+- Zwei Schaltflächen zum Senden von IPv4- bzw. IPv6-Pings
+- Logfenster mit automatischem Scrollen für alle Ausgaben
+- Plattformübergreifendes `ping`-Kommando
+- Einfache Tests zum Überprüfen der Funktion
+
+## Starten
+
+```bash
+python ping_gui.py
+```
+
+## Tests
+
+```bash
+pytest -q
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
-# CodexTest
-CodexTest
+# Ping GUI Test App
+
+This repository contains a small Python application with a graphical user
+interface for sending IPv4 and IPv6 ping requests.  Results are displayed in a
+scrollable log window.
+
+## Requirements
+
+- Python 3.10+
+- Tkinter (usually included with Python)
+- `ping` command available in the system
+- Optional: [`pytest`](https://pytest.org/) for running tests
+
+## Usage
+
+Run the GUI:
+
+```bash
+python ping_gui.py
+```
+
+Enter a host name or IP address and click **Ping IPv4** or **Ping IPv6** to see
+results in the log window.
+
+## Running Tests
+
+To verify the ping helper functions without starting the GUI, run:
+
+```bash
+pytest -q
+```
+
+The tests ping the local host for both IPv4 and IPv6. The IPv6 test is skipped
+if no IPv6 stack is available.
+
+## Project Structure
+
+- `ping_utils.py` – helper function for executing ping commands
+- `ping_gui.py` – Tkinter user interface
+- `tests/` – basic unit tests
+- `requirements.txt` – optional development dependency

--- a/ping_gui.py
+++ b/ping_gui.py
@@ -1,0 +1,68 @@
+import threading
+import tkinter as tk
+from tkinter import ttk
+
+from ping_utils import ping
+
+
+class PingApp(ttk.Frame):
+    """Simple GUI application for IPv4 and IPv6 ping."""
+
+    def __init__(self, master: tk.Tk) -> None:
+        super().__init__(master, padding=10)
+        master.title("Ping GUI")
+        master.geometry("420x300")
+        self.pack(fill="both", expand=True)
+
+        self.address_var = tk.StringVar(value="8.8.8.8")
+
+        entry = ttk.Entry(self, textvariable=self.address_var)
+        entry.pack(fill="x", pady=(0, 5))
+
+        btn_frame = ttk.Frame(self)
+        btn_frame.pack(fill="x", pady=(0, 5))
+
+        ttk.Button(btn_frame, text="Ping IPv4", command=lambda: self.start_ping(4)).pack(
+            side="left", expand=True, fill="x"
+        )
+        ttk.Button(btn_frame, text="Ping IPv6", command=lambda: self.start_ping(6)).pack(
+            side="left", expand=True, fill="x"
+        )
+
+        self.log = tk.Text(self, state="disabled", height=10)
+        self.log.pack(fill="both", expand=True)
+
+    # GUI helpers
+    def append_log(self, message: str) -> None:
+        self.log.configure(state="normal")
+        self.log.insert("end", message + "\n")
+        self.log.see("end")
+        self.log.configure(state="disabled")
+
+    # Ping handling
+    def start_ping(self, version: int) -> None:
+        address = self.address_var.get().strip()
+        threading.Thread(target=self.run_ping, args=(address, version), daemon=True).start()
+
+    def run_ping(self, address: str, version: int) -> None:
+        self.append_log(f"Pinging {address} (IPv{version})...")
+        result = ping(address, version)
+        if result["success"]:
+            elapsed = f"{result['elapsed_ms']} ms" if result["elapsed_ms"] is not None else "?"
+            self.append_log(f"Success ({elapsed})")
+        else:
+            self.append_log("Failed")
+        if result.get("output"):
+            self.append_log(result["output"])
+        if result.get("error"):
+            self.append_log(result["error"])
+
+
+def main() -> None:
+    root = tk.Tk()
+    PingApp(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/ping_utils.py
+++ b/ping_utils.py
@@ -1,0 +1,59 @@
+import platform
+import subprocess
+from typing import Dict, Optional
+
+
+def ping(address: str, version: int = 4, count: int = 1, timeout: int = 2) -> Dict[str, Optional[str]]:
+    """Ping an address using IPv4 or IPv6.
+
+    Parameters
+    ----------
+    address: str
+        Hostname or IP address to ping.
+    version: int
+        IP version (4 or 6).
+    count: int
+        Number of echo requests to send.
+    timeout: int
+        Time to wait for a response in seconds (Linux/Mac only).
+
+    Returns
+    -------
+    dict
+        Mapping containing ``success`` (bool), ``output`` (str),
+        ``elapsed_ms`` (float or None) and ``error`` (str or None).
+    """
+    if version not in (4, 6):
+        raise ValueError("version must be 4 or 6")
+
+    system = platform.system().lower()
+    if system == "windows":
+        cmd = ["ping", f"-{version}", "-n", str(count), address]
+    else:
+        # Linux and macOS
+        cmd = ["ping", f"-{version}", "-c", str(count), "-W", str(timeout), address]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        success = result.returncode == 0
+    except Exception as exc:
+        return {"success": False, "output": "", "elapsed_ms": None, "error": str(exc)}
+
+    elapsed_ms = None
+    if success:
+        import re
+
+        match = re.search(r"time[=<]([\d\.]+) ?ms", result.stdout)
+        if match:
+            elapsed_ms = float(match.group(1))
+        else:
+            match = re.search(r"Average = ([\d\.]+)ms", result.stdout)
+            if match:
+                elapsed_ms = float(match.group(1))
+
+    return {
+        "success": success,
+        "output": result.stdout.strip(),
+        "elapsed_ms": elapsed_ms,
+        "error": None,
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# Application uses Python standard library only.
+# For running tests:
+pytest>=8.0

--- a/tests/test_ping_utils.py
+++ b/tests/test_ping_utils.py
@@ -1,0 +1,21 @@
+import pathlib
+import sys
+
+import pytest
+
+# Ensure project root is on sys.path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from ping_utils import ping
+
+
+def test_ping_ipv4_localhost():
+    result = ping("127.0.0.1", 4)
+    assert result["success"], result["output"]
+
+
+def test_ping_ipv6_localhost():
+    result = ping("::1", 6)
+    if not result["success"]:
+        pytest.skip("IPv6 not available")
+    assert result["success"], result["output"]


### PR DESCRIPTION
## Summary
- build `ping_utils.py` to run IPv4/IPv6 pings cross‑platform
- add Tkinter interface with log window for sending pings
- document usage and add tests for local IPv4/IPv6

## Testing
- `python -m py_compile ping_utils.py ping_gui.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68923974644483289138edabbb8c4b25